### PR TITLE
Fix arrow keys not working correctly

### DIFF
--- a/recordings-ui.xml
+++ b/recordings-ui.xml
@@ -23,7 +23,7 @@
         <!--     <value>Watch Recordings</value> -->
         <!-- </textarea> -->
 
-	<group name="groupgroup" depends="!coverart">
+	<group name="groupgroup">
 
 	    <!-- <animation trigger="AboutToShow"> -->
 	    <!-- 	<section duration="500"> -->


### PR DESCRIPTION
Trying to set focus to a nonexistent widget was not working, so
I removed the depends condition from the groups list.
Port Changes from https://github.com/MythTV-Themes/Mythbuntu/commit/72974c95052641b979e803a0e0f5f80f5878f8d0